### PR TITLE
Fix install_prereqs.sh scripts for building on Fedora

### DIFF
--- a/scripts/install_prereq.sh
+++ b/scripts/install_prereq.sh
@@ -6,7 +6,7 @@
 
 # -- Core
 PACKAGES_DEBIAN="build-essential git" # make, git
-PACKAGES_FEDORA="git gcc binutils-devel"
+PACKAGES_FEDORA="git gcc binutils-devel wget autoconf libtool"
 
 # used by libopenarc, libetpan
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN make automake pkg-config libtool m4"
@@ -35,7 +35,7 @@ PACKAGES_FEDORA="$PACKAGES_FEDORA libuuid-devel"
 
 # <bsd/string.h>
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN libbsd-dev"
-PACKAGES_FEDORA="$PACKAGES_DEBIAN libbsd-devel"
+PACKAGES_FEDORA="$PACKAGES_FEDORA libbsd-devel"
 
 # <histedit.h>, <readline/history.h>
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN libedit-dev libreadline-dev"
@@ -47,13 +47,11 @@ PACKAGES_DEBIAN="$PACKAGES_DEBIAN libssh-dev"
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN binutils" # objdump
 PACKAGES_FEDORA="$PACKAGES_FEDORA libssh-devel"
 
-# lirc (mod_irc_client)
-scripts/lirc.sh
-
 # MariaDB (MySQL) dev headers (mod_mysql, mod_mysql_auth)
-# mariadb-server is also required to run a local DBMS, but this is not required for either compilation or operation.
+# mariadb-server is also required to run a local DBMS, but this is not
+# required for either compilation or operation.
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN libmariadb-dev libmariadb-dev-compat"
-PACKAGES_FEDORA="$PACKAGES_FEDORA mariadb105-devel"
+PACKAGES_FEDORA="$PACKAGES_FEDORA mariadb-devel"
 
 # LMDB (mod_lmdb)
 PACKAGES_DEBIAN="$PACKAGES_DEBIAN liblmdb-dev"
@@ -101,6 +99,9 @@ else
 fi
 
 # == Source Install
+
+# lirc (mod_irc_client)
+scripts/lirc.sh
 
 # libdiscord (mod_discord)
 scripts/libdiscord.sh


### PR DESCRIPTION
There were several issues with the install_prereqs.sh script:

- It was trying to run scripts/lirc.sh *before* installing packages,
  which would cause everything to fail.

- It added `PACKAGES_DEBIAN` to `PACKAGES_FEDORA`, resulting in a failed
  package install.

- It fails to install `wget`, which is required by one of the builds.

- If fails to install `autoconf` and `libtool`, causing configure
  script invocations to fail

Note that even with these fixes the libetpan build still fails; that will
need to be addressed in a future PR.
