### PR TITLE
Build libetpan before evergreen

### DIFF
--- a/scripts/install_prereq.sh
+++ b/scripts/install_prereq.sh
@@ -137,6 +137,10 @@ scripts/libdiscord.sh
 # libwss (net_ws)
 scripts/libwss.sh
 
+# libetpan (mod_webmail): the package no longer suffices, since we patch the source.
+#PACKAGES_DEBIAN="$PACKAGES_DEBIAN libetpan-dev"
+scripts/libetpan.sh
+
 # evergreen (door_evergreen)
 scripts/evergreen.sh
 
@@ -145,10 +149,6 @@ scripts/libslackrtm.sh
 
 # mod_smtp_filter_arc
 scripts/libopenarc.sh
-
-# libetpan (mod_webmail): the package no longer suffices, since we patch the source.
-#PACKAGES_DEBIAN="$PACKAGES_DEBIAN libetpan-dev"
-scripts/libetpan.sh
 
 # doxygen only:
 #PACKAGES_DEBIAN="$PACKAGES_DEBIAN doxygen graphviz"


### PR DESCRIPTION
I noticed the evergreen binary wasn't being built and on further inspection this was due to `libetpan.h` being missing.

This PR changes the order so libetpan is compiled before evergreen

N.B, this error wasn't abundantly obvious and install_prereq.sh continued after the error - I'm not sure why `set -e` didn't catch it