### PR TITLE
install_prereq.sh: Replace conflicting SUSE packages if needed.

### DIFF
--- a/scripts/install_prereq.sh
+++ b/scripts/install_prereq.sh
@@ -204,6 +204,7 @@ elif [ -f /etc/redhat-release ]; then
 	dnf install -y $PACKAGES_RHEL
 elif [ "$OS_DIST_INFO" = "SLES" ] || [ "$OS_DIST_INFO" = "openSUSE Tumbleweed" ]; then
 	zypper update -y
+	zypper dup -y
 	zypper install --no-confirm $PACKAGES_SUSE
 elif [ -r /etc/arch-release ]; then
 	pacman -Syu --noconfirm


### PR DESCRIPTION
Fix a build failure in the CI caused by automatic cancellation in response to multi-solution failure.