### PR TITLE
fix(net_ssh): use filename parameter instead of hardcoded RSA path in bind_key

### DIFF
--- a/nets/net_ssh.c
+++ b/nets/net_ssh.c
@@ -109,7 +109,7 @@ static int bind_key(enum ssh_bind_options_e opt, const char *filename)
 		bbs_warning("Can't access key %s - missing or not readable?\n", filename);
 		return 0;
 	}
-	return ssh_bind_options_set(sshbind, opt, KEYS_FOLDER "ssh_host_rsa_key") ? 0 : 1;
+	return ssh_bind_options_set(sshbind, opt, filename) ? 0 : 1;
 }
 
 static int start_ssh(void)


### PR DESCRIPTION
## Bug

`bind_key()` in `nets/net_ssh.c` (line 112) passes a hardcoded `KEYS_FOLDER "ssh_host_rsa_key"` to `ssh_bind_options_set()` regardless of the `filename` argument, causing all non-RSA key types to fail to load.

## Current code

```c
static int bind_key(enum ssh_bind_options_e opt, const char *filename)
{
    if (eaccess(filename, R_OK)) {
        bbs_warning("Can't access key %s - missing or not readable?\n", filename);
        return 0;
    }
    return ssh_bind_options_set(sshbind, opt, KEYS_FOLDER "ssh_host_rsa_key") ? 0 : 1;
}
```

## Expected

```c
    return ssh_bind_options_set(sshbind, opt, filename) ? 0 : 1;
```

## Impact

If the system only has an ed25519 key (no RSA key), `net_ssh` fails to start with:

```
ERROR: net_ssh.c:145 start_ssh: Failed to configure listener, unable to bind any SSH keys
```

The `eaccess()` check passes for the ed25519 key, but then `ssh_bind_options_set` is called with the RSA path which doesn't exist, so it silently fails and returns 0 keys bound.

## Environment

- LBBS master branch (cloned 2026-06-06)
- Debian 13 (Trixie), libssh 0.11.2
- Config: `[keys]` with only `ed25519 = yes`, rsa/dsa/ecdsa = no

## Fix

One-line change — replace the hardcoded string with the `filename` parameter on line 112.