### PR TITLE
nntp_spool_trad.c: Fix CRLF termination in OVER/XOVER responses.

### DIFF
--- a/nets/net_nntp/nntp_spool_trad.c
+++ b/nets/net_nntp/nntp_spool_trad.c
@@ -881,13 +881,16 @@ static int tradspool_group_overview_full(struct nntp_session *nntp, enum overvie
 				}
 			} else {
 				/* OVER and XOVER responses */
+
+				bbs_term_line(buf); /* msgbuf (from .overview file) only includes LF, strip LF to use CR LF instead */
+
 				if (messageid && !eff_artnum) {
 					/* Need to respond with article number 0 instead */
 					char *rest = buf;
 					strsep(&rest, "\t");
-					_nntp_send(nntp, "%d\t%s", 0, rest); /* msgbuf already includes CR LF */
+					_nntp_send(nntp, "%d\t%s\r\n", 0, rest);
 				} else {
-					_nntp_send(nntp, "%s", buf); /* msgbuf already includes CR LF */
+					_nntp_send(nntp, "%s\r\n", buf);
 				}
 			}
 		}


### PR DESCRIPTION
When I tried to use Thunderbird to connect to an NNTP server running lbbs, I found that it was stuck at "Downloading _n_ headers in _newsgroup_". Then GPT-5.6 Sol found that it was caused by the LF-only line endings in OVER/XOVER command.

This problem can be verified by:
```
$ nc -C bbs.phreaknet.org 119 | cat -A
200 news.phreaknet.org Newsgroup Service Ready, posting allowed^M$
MODE READER
200 Reader mode, posting permitted^M$
GROUP alt.2600
211 640 1 640 alt.2600^M$
OVER 1-3
224 Overview information follows^M$
1^IAntes de la Web: El =?UTF-8?Q?sue=C3=B1o?= ochentero de un mundo virtual libre y sin fronteras^Irek2 hispagatos <rek2@hispagatos.org.invalid>^ITue, 30 Jul 2024 22:22:12 -0000 (UTC)^I<v8bp2k$1bvcu$1@matrix.hispagatos.org>^I^I1461^I21^IXref: news.phreaknet.org alt.2600:1 alt.2600.hackers:1$
2^IWiFi Router Can Watch You / Encryption Prescanning / Assange Released^Irek2 hispagatos <rek2@hispagatos.org.invalid>^ITue, 30 Jul 2024 22:32:21 -0000 (UTC)^I<v8bpll$1bvcu$2@matrix.hispagatos.org>^I^I1400^I14^IXref: news.phreaknet.org alt.2600:2 alt.2600.hackers:2$
3^IHow to Gain Instant ESXi Admin - ThreatWire^Irek2 hispagatos <rek2@hispagatos.org.invalid>^IWed, 31 Jul 2024 16:23:28 -0000 (UTC)^I<v8doe0$1dbhn$1@matrix.hispagatos.org>^I^I1328^I30^IXref: news.phreaknet.org alt.2600:3 alt.2600.hackers:3$
.^M$
QUIT
205 Bye!^M$
```

I manually read the source code to fix it and test it. After this change Thunderbird can download headers successfully.

P.S. English is not my native language; please excuse typing errors. 