### PR TITLE
nntp_spool_trad.c: Fix :bytes typo.

### DIFF
--- a/nets/net_nntp/nntp_spool_trad.c
+++ b/nets/net_nntp/nntp_spool_trad.c
@@ -944,7 +944,7 @@ int tradspool_overview_header_list(struct nntp_session *nntp, enum list_category
 		_nntp_send(nntp, "Date:\r\n");
 		_nntp_send(nntp, "Message-ID:\r\n");
 		_nntp_send(nntp, "References:\r\n");
-		_nntp_send(nntp, ":bytes:\r\n");
+		_nntp_send(nntp, ":bytes\r\n");
 		_nntp_send(nntp, ":lines\r\n");
 		_nntp_send(nntp, "Xref:full\r\n");
 	}


### PR DESCRIPTION
This problem was found while fixing #58 .

According to https://datatracker.ietf.org/doc/html/rfc3977#section-8.4 LIST OVERVIEW.FMT should return `:bytes` or `Bytes:` instead of `:bytes:`. This should be a typo.